### PR TITLE
Add compile-time validation for Python-specific syntax in Starlark ma…

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -533,7 +533,7 @@ body {
 /* Notifications */
 .notifications {
     position: fixed;
-    top: 20px;
+    bottom: 20px;
     right: 20px;
     z-index: 3000;
     display: flex;
@@ -548,7 +548,7 @@ body {
     padding: 12px 16px;
     min-width: 300px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-    animation: slideIn 0.3s ease-out;
+    animation: slideInFromBottom 0.3s ease-out;
 }
 
 @keyframes slideIn {
@@ -558,6 +558,17 @@ body {
     }
     to {
         transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+@keyframes slideInFromBottom {
+    from {
+        transform: translateY(100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
         opacity: 1;
     }
 }

--- a/editor/js/app.js
+++ b/editor/js/app.js
@@ -235,20 +235,35 @@ class GottpEditor {
             let compileTime = null;
             let executionTime = null;
             
-            // Compile template if needed
-            if (!this.state.compiledTemplate) {
+            // Compile template if needed (always compile to check for warnings)
+            if (!this.state.compiledTemplate || this.state.templateCacheKey !== this.state.template) {
                 this.showNotification('Compiling template...', 'info');
                 try {
                     const compileStart = performance.now();
                     const compileResult = await wasmBridge.compileTemplate(this.state.template);
                     compileTime = performance.now() - compileStart;
+                    
                     // Store both JSON and cache key for faster parsing
                     this.state.compiledTemplate = compileResult.compiledJSON || compileResult;
                     this.state.templateCacheKey = compileResult.cacheKey || this.state.template;
+                    
+                    // Display compilation warnings if any
+                    if (compileResult.warnings && compileResult.warnings.length > 0) {
+                        const warningsText = compileResult.warnings.join('\n');
+                        this.showNotification(`Compilation warnings:\n${warningsText}`, 'warning');
+                        
+                        // Set Monaco editor markers for macro warnings
+                        this.setMacroWarnings(compileResult.warnings);
+                    } else {
+                        // Clear macro warning markers if no warnings
+                        this.clearMacroWarnings();
+                    }
                 } catch (compileError) {
                     // Clear compiled template on error so we retry next time
                     this.state.compiledTemplate = null;
                     this.state.templateCacheKey = null;
+                    // Clear macro warnings on error
+                    this.clearMacroWarnings();
                     throw compileError;
                 }
             }
@@ -1236,6 +1251,99 @@ class GottpEditor {
             }
             this.showNotification(`YANG Validation: ${messages.join(', ')}`, totalErrors > 0 ? 'error' : 'warning');
         }
+    }
+    
+    /**
+     * Set Monaco editor markers for macro compilation warnings
+     * @param {Array<string>} warnings - Array of warning messages
+     */
+    setMacroWarnings(warnings) {
+        if (!templateEditor || !warnings || warnings.length === 0) {
+            return;
+        }
+        
+        const model = templateEditor.getModel();
+        const templateText = model.getValue();
+        const markers = [];
+        
+        // Find all <macro> tags in the template
+        const macroRegex = /<macro[^>]*>([\s\S]*?)<\/macro>/gi;
+        let macroMatch;
+        let macroIndex = 0;
+        
+        while ((macroMatch = macroRegex.exec(templateText)) !== null) {
+            const macroContent = macroMatch[1];
+            const macroStartIndex = macroMatch.index;
+            const macroTagStart = macroMatch[0].indexOf('>') + 1;
+            const macroContentStart = macroStartIndex + macroTagStart;
+            
+            // Find line number for the start of this macro
+            const beforeMacro = templateText.substring(0, macroContentStart);
+            const macroStartLine = (beforeMacro.match(/\n/g) || []).length + 1;
+            
+            // Check each warning to see if it's for this macro
+            for (const warning of warnings) {
+                // Extract line number from warning if present (format: "on line X")
+                const lineMatch = warning.match(/on line (\d+)/i);
+                let warningLine = null;
+                if (lineMatch) {
+                    warningLine = parseInt(lineMatch[1], 10);
+                }
+                
+                // If warning mentions a line number, use it relative to macro start
+                // Otherwise, mark the first line of the macro content
+                let actualLine = macroStartLine;
+                if (warningLine && warningLine > 0) {
+                    // Count lines in macro content
+                    const macroLines = macroContent.split('\n');
+                    if (warningLine <= macroLines.length) {
+                        actualLine = macroStartLine + warningLine - 1;
+                    } else {
+                        actualLine = macroStartLine + macroLines.length - 1;
+                    }
+                } else {
+                    // No line number, mark the first line of macro content (after the <macro> tag)
+                    actualLine = macroStartLine + 1;
+                }
+                
+                const cleanMessage = warning.replace(/^macro \(language=[^)]+\): /, ''); // Remove language prefix
+                
+                markers.push({
+                    severity: monaco.MarkerSeverity.Warning,
+                    startLineNumber: actualLine,
+                    startColumn: 1,
+                    endLineNumber: actualLine,
+                    endColumn: 999,
+                    message: cleanMessage
+                });
+            }
+            
+            macroIndex++;
+        }
+        
+        // If we couldn't find macro tags but have warnings, mark the first line
+        if (markers.length === 0 && warnings.length > 0) {
+            markers.push({
+                severity: monaco.MarkerSeverity.Warning,
+                startLineNumber: 1,
+                startColumn: 1,
+                endLineNumber: 1,
+                endColumn: 999,
+                message: warnings[0].replace(/^macro \(language=[^)]+\): /, '')
+            });
+        }
+        
+        monaco.editor.setModelMarkers(model, 'macro-warnings', markers);
+    }
+    
+    /**
+     * Clear macro warning markers
+     */
+    clearMacroWarnings() {
+        if (!templateEditor) return;
+        
+        const model = templateEditor.getModel();
+        monaco.editor.setModelMarkers(model, 'macro-warnings', []);
     }
     
     setupOptionsHandlers() {

--- a/editor/js/wasm-bridge.js
+++ b/editor/js/wasm-bridge.js
@@ -114,10 +114,26 @@ class GottpWasmBridge {
                 throw new Error(resultObj.error);
             }
 
-            // Return both JSON and cache key
+            // Return both JSON and cache key, plus warnings
+            let warnings = [];
+            if (resultObj.warnings) {
+                // Check if it's already an array (from jsValueToObject conversion)
+                if (Array.isArray(resultObj.warnings)) {
+                    warnings = resultObj.warnings;
+                } else if (typeof resultObj.warnings === 'string') {
+                    // It's a JSON string, parse it
+                    try {
+                        warnings = JSON.parse(resultObj.warnings);
+                    } catch (e) {
+                        // If parsing fails, ignore warnings
+                    }
+                }
+            }
+            
             return {
                 compiledJSON: resultObj.result,
-                cacheKey: resultObj.cacheKey || templateText
+                cacheKey: resultObj.cacheKey || templateText,
+                warnings: warnings
             };
         } catch (error) {
             throw new Error(`Template compilation failed: ${error.message}`);
@@ -312,8 +328,13 @@ class GottpWasmBridge {
         }
 
         const obj = {};
-        const keys = Object.keys(jsValue);
+        // Use Object.getOwnPropertyNames to get all properties, including non-enumerable ones
+        const keys = Object.getOwnPropertyNames(jsValue);
         for (const key of keys) {
+            // Skip internal properties
+            if (key.startsWith('_') || key === 'constructor' || key === 'prototype') {
+                continue;
+            }
             const value = jsValue[key];
             if (value && typeof value === 'object' && value.constructor && value.constructor.name === 'Object') {
                 obj[key] = this.jsValueToObject(value);

--- a/editor/wasm/main.go
+++ b/editor/wasm/main.go
@@ -51,11 +51,29 @@ func compileTemplate(this js.Value, args []js.Value) interface{} {
 		}
 	}
 
-	return map[string]interface{}{
-		"result":   string(compiledJSON),
-		"cacheKey": cacheKey,
-		"error":    nil,
+	// Get compilation warnings
+	warnings := compiled.GetWarnings()
+	warningsJSON, marshalErr := json.Marshal(warnings)
+	if marshalErr != nil {
+		warningsJSON = []byte("[]")
 	}
+
+	// Create result object - ensure all fields are explicitly set
+	// Go WASM may drop nil values, so we use empty string for error if nil
+	resultError := ""
+	if err != nil {
+		resultError = err.Error()
+	}
+
+	// Create result map and explicitly set all fields
+	// Using js.ValueOf on the map should preserve all fields
+	result := make(map[string]interface{})
+	result["result"] = string(compiledJSON)
+	result["cacheKey"] = cacheKey
+	result["warnings"] = string(warningsJSON)
+	result["error"] = resultError
+
+	return result
 }
 
 // parseTemplate parses input data using a compiled template

--- a/gottp.go
+++ b/gottp.go
@@ -68,6 +68,14 @@ type CompiledTemplate struct {
 	compiled *compiler.CompiledTemplate
 }
 
+// GetWarnings returns compilation warnings (non-fatal issues like Python-specific syntax in Starlark macros)
+func (ct *CompiledTemplate) GetWarnings() []string {
+	if ct.compiled == nil {
+		return []string{}
+	}
+	return ct.compiled.Warnings
+}
+
 // ParseResult contains the parsed results and validation results
 type ParseResult struct {
 	Data             interface{}                          // Parsed data

--- a/gottp_test.go
+++ b/gottp_test.go
@@ -1,0 +1,105 @@
+package gottp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompiledTemplate_GetWarnings(t *testing.T) {
+	tests := []struct {
+		name           string
+		template       string
+		wantWarnings   bool
+		wantFString    bool
+		wantConcatenation bool
+	}{
+		{
+			name: "template with f-string warning",
+			template: `<template>
+<macro>
+def test(data):
+    return f"{data}"
+</macro>
+<group name="test">test</group>
+</template>`,
+			wantWarnings:   true,
+			wantFString:    true,
+			wantConcatenation: false,
+		},
+		{
+			name: "template with implicit concatenation warning",
+			template: `<template>
+<macro>
+def test():
+    return "hello" "world"
+</macro>
+<group name="test">test</group>
+</template>`,
+			wantWarnings:   true,
+			wantFString:    false,
+			wantConcatenation: true,
+		},
+		{
+			name: "template with no warnings",
+			template: `<template>
+<macro>
+def test(data):
+    return str(data) + ".txt"
+</macro>
+<group name="test">test</group>
+</template>`,
+			wantWarnings:   false,
+			wantFString:    false,
+			wantConcatenation: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compiled, err := CompileTemplate(tt.template)
+			if err != nil {
+				t.Fatalf("Failed to compile template: %v", err)
+			}
+
+			warnings := compiled.GetWarnings()
+			hasWarnings := len(warnings) > 0
+
+			if hasWarnings != tt.wantWarnings {
+				t.Errorf("GetWarnings() has warnings = %v, want %v. Warnings: %v", hasWarnings, tt.wantWarnings, warnings)
+			}
+
+			if tt.wantWarnings {
+				hasFString := false
+				hasConcatenation := false
+				for _, w := range warnings {
+					if strings.Contains(w, "f-string") {
+						hasFString = true
+					}
+					if strings.Contains(w, "implicit string concatenation") {
+						hasConcatenation = true
+					}
+				}
+
+				if hasFString != tt.wantFString {
+					t.Errorf("GetWarnings() f-string warning = %v, want %v", hasFString, tt.wantFString)
+				}
+				if hasConcatenation != tt.wantConcatenation {
+					t.Errorf("GetWarnings() concatenation warning = %v, want %v", hasConcatenation, tt.wantConcatenation)
+				}
+			}
+		})
+	}
+}
+
+func TestCompiledTemplate_GetWarnings_EmptyTemplate(t *testing.T) {
+	compiled, err := CompileTemplate(`<template><group name="test">test</group></template>`)
+	if err != nil {
+		t.Fatalf("Failed to compile template: %v", err)
+	}
+
+	warnings := compiled.GetWarnings()
+	if len(warnings) != 0 {
+		t.Errorf("Expected no warnings for template without macros, got: %v", warnings)
+	}
+}
+

--- a/internal/compiler/compiled.go
+++ b/internal/compiler/compiled.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/roc-ops/gottp/internal/parser"
 	"github.com/roc-ops/gottp/internal/pattern"
+	"github.com/roc-ops/gottp/internal/validator"
 	"github.com/roc-ops/gottp/internal/variable"
 )
 
@@ -46,6 +47,9 @@ type CompiledTemplate struct {
 
 	// Version for compatibility checking
 	Version string
+
+	// Compilation warnings (non-fatal issues like Python-specific syntax in Starlark macros)
+	Warnings []string
 }
 
 // CompiledVarsWithName represents compiled vars with name attribute
@@ -146,6 +150,7 @@ func (c *Compiler) CompileTemplate(tmpl *parser.Template) (*CompiledTemplate, er
 		Version:       "1.0.0", // TODO: use actual version
 		Vars:          make(map[string]interface{}),
 		VarsWithName:  []*CompiledVarsWithName{},
+		Warnings:      []string{},
 	}
 
 	// Parse and copy vars
@@ -325,7 +330,7 @@ func (c *Compiler) CompileTemplate(tmpl *parser.Template) (*CompiledTemplate, er
 		compiled.Lookups = append(compiled.Lookups, compiledLookup)
 	}
 
-	// Compile macros
+	// Compile macros and validate for Starlark compatibility
 	for _, macro := range tmpl.Macros {
 		compiledMacro := &CompiledMacro{
 			Language:   macro.Language,
@@ -333,6 +338,12 @@ func (c *Compiler) CompileTemplate(tmpl *parser.Template) (*CompiledTemplate, er
 			Attributes: macro.Attributes,
 		}
 		compiled.Macros = append(compiled.Macros, compiledMacro)
+		
+		// Validate macro source for Python-specific syntax that's not compatible with Starlark
+		macroWarnings := validator.ValidateMacroSource(macro.Content, macro.Language)
+		for _, warning := range macroWarnings {
+			compiled.Warnings = append(compiled.Warnings, fmt.Sprintf("macro (language=%s): %s", macro.Language, warning))
+		}
 	}
 
 	// Compile child templates

--- a/internal/compiler/compiled_test.go
+++ b/internal/compiler/compiled_test.go
@@ -1,0 +1,166 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/roc-ops/gottp/internal/parser"
+)
+
+func TestCompiler_CompileTemplate_MacroWarnings(t *testing.T) {
+	tests := []struct {
+		name           string
+		template       string
+		wantFString    bool
+		wantConcatenation bool
+	}{
+		{
+			name: "macro with f-string",
+			template: `<template>
+<macro>
+def test(data):
+    return f"{data}"
+</macro>
+<group name="test">test</group>
+</template>`,
+			wantFString:    true,
+			wantConcatenation: false,
+		},
+		{
+			name: "macro with implicit string concatenation",
+			template: `<template>
+<macro>
+def test():
+    return "hello" "world"
+</macro>
+<group name="test">test</group>
+</template>`,
+			wantFString:    false,
+			wantConcatenation: true,
+		},
+		{
+			name: "macro with both issues",
+			template: `<template>
+<macro>
+def test(data):
+    return f"{data}" "extra"
+</macro>
+<group name="test">test</group>
+</template>`,
+			wantFString:    true,
+			wantConcatenation: true,
+		},
+		{
+			name: "valid macro (no warnings)",
+			template: `<template>
+<macro>
+def test(data):
+    return str(data) + ".txt"
+</macro>
+<group name="test">test</group>
+</template>`,
+			wantFString:    false,
+			wantConcatenation: false,
+		},
+		{
+			name: "Python macro (should not warn)",
+			template: `<template>
+<macro language="python">
+def test(data):
+    return f"{data}"
+</macro>
+<group name="test">test</group>
+</template>`,
+			wantFString:    false,
+			wantConcatenation: false,
+		},
+		{
+			name: "multiple macros with warnings",
+			template: `<template>
+<macro>
+def test1(data):
+    return f"{data}"
+</macro>
+<macro>
+def test2():
+    return "a" "b"
+</macro>
+<group name="test">test</group>
+</template>`,
+			wantFString:    true,
+			wantConcatenation: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Parse template
+			tmpl, err := parser.ParseTemplate(tt.template)
+			if err != nil {
+				t.Fatalf("Failed to parse template: %v", err)
+			}
+
+			// Compile template
+			comp := NewCompiler()
+			compiled, err := comp.CompileTemplate(tmpl)
+			if err != nil {
+				t.Fatalf("Failed to compile template: %v", err)
+			}
+
+			// Check warnings
+			hasFString := false
+			hasConcatenation := false
+			for _, warning := range compiled.Warnings {
+				if strings.Contains(warning, "f-string") {
+					hasFString = true
+				}
+				if strings.Contains(warning, "implicit string concatenation") {
+					hasConcatenation = true
+				}
+			}
+
+			if hasFString != tt.wantFString {
+				t.Errorf("CompileTemplate() f-string warning = %v, want %v. Warnings: %v", hasFString, tt.wantFString, compiled.Warnings)
+			}
+			if hasConcatenation != tt.wantConcatenation {
+				t.Errorf("CompileTemplate() concatenation warning = %v, want %v. Warnings: %v", hasConcatenation, tt.wantConcatenation, compiled.Warnings)
+			}
+		})
+	}
+}
+
+func TestCompiler_CompileTemplate_NoWarningsForValidMacros(t *testing.T) {
+	// Test the user's example - valid Starlark string concatenation
+	template := `<template>
+<macro>
+def versions(data):
+    software_version = str(data["major"]) + "." + \
+                       str(data["minor"]) + "." + \
+                       str(data["patch"]) + ", Ver " + \
+                       str(data["version"]) + "," + \
+                       str(data["build"])
+    data["software-version"] = software_version
+    return data
+</macro>
+<group name="version-info" macro="versions">
+Running Image: {{smm-type}} Rel {{major}}.{{minor}}.{{patch}}, Ver {{version | re('[^,]+')}},{{build}}, {{date | re('[^,]+')}},(relmgr)
+</group>
+</template>`
+
+	tmpl, err := parser.ParseTemplate(template)
+	if err != nil {
+		t.Fatalf("Failed to parse template: %v", err)
+	}
+
+	comp := NewCompiler()
+	compiled, err := comp.CompileTemplate(tmpl)
+	if err != nil {
+		t.Fatalf("Failed to compile template: %v", err)
+	}
+
+	// Should have no warnings for valid Starlark syntax
+	if len(compiled.Warnings) > 0 {
+		t.Errorf("Expected no warnings for valid macro, got: %v", compiled.Warnings)
+	}
+}
+

--- a/internal/macro/starlark_test.go
+++ b/internal/macro/starlark_test.go
@@ -1,6 +1,7 @@
 package macro
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -205,6 +206,29 @@ def func3(data):
 		if !found {
 			t.Errorf("extractFunctionNames() missing function: %s", expectedName)
 		}
+	}
+}
+
+// TestStarlarkEngine_PythonFStringRejection tests that Python f-string syntax is rejected
+// F-strings are not supported in Starlark and should cause a compilation error
+// Users should use string concatenation with + or .format() instead
+func TestStarlarkEngine_PythonFStringRejection(t *testing.T) {
+	engine := NewStarlarkEngine()
+	
+	// Test with f-string - should fail to compile
+	source := `def test_func(data):
+    result = f"{data.get('key', 'default')}"
+    return {"result": result}`
+	
+	err := engine.RegisterMacroSource(source)
+	if err == nil {
+		t.Fatal("Expected error when registering macro with f-string, but got none")
+	}
+	
+	// Verify the error mentions f-string or syntax error
+	if !strings.Contains(err.Error(), "f") && !strings.Contains(err.Error(), "syntax") {
+		t.Logf("Error message: %v", err)
+		// This is acceptable - any compilation error is fine
 	}
 }
 

--- a/internal/validator/macro_validation_test.go
+++ b/internal/validator/macro_validation_test.go
@@ -1,0 +1,269 @@
+package validator
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateMacroSource_FStringDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		language string
+		wantWarn bool
+	}{
+		{
+			name:     "f-string with double quotes",
+			source:   `def test(data): return f"{data}"`,
+			language: "starlark",
+			wantWarn: true,
+		},
+		{
+			name:     "f-string with single quotes",
+			source:   `def test(data): return f'{data}'`,
+			language: "starlark",
+			wantWarn: true,
+		},
+		{
+			name:     "f-string in multiline macro",
+			source:   "def test(data):\n    result = f\"{data.get('key')}\"\n    return result",
+			language: "starlark",
+			wantWarn: true,
+		},
+		{
+			name:     "no f-string",
+			source:   `def test(data): return str(data) + ".txt"`,
+			language: "starlark",
+			wantWarn: false,
+		},
+		{
+			name:     "f-string in Python macro (should not warn)",
+			source:   `def test(data): return f"{data}"`,
+			language: "python",
+			wantWarn: false,
+		},
+		{
+			name:     "f-string in JavaScript macro (should not warn)",
+			source:   "function test(data) { return `${data}`; }",
+			language: "javascript",
+			wantWarn: false,
+		},
+		{
+			name:     "empty language defaults to starlark",
+			source:   `def test(data): return f"{data}"`,
+			language: "",
+			wantWarn: true,
+		},
+		{
+			name:     "word boundary - 'if' should not match",
+			source:   `def test(data): if data: return "value"`,
+			language: "starlark",
+			wantWarn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := ValidateMacroSource(tt.source, tt.language)
+			hasFStringWarning := false
+			for _, w := range warnings {
+				if strings.Contains(w, "f-string") {
+					hasFStringWarning = true
+					break
+				}
+			}
+
+			if hasFStringWarning != tt.wantWarn {
+				t.Errorf("ValidateMacroSource() f-string warning = %v, want %v. Warnings: %v", hasFStringWarning, tt.wantWarn, warnings)
+			}
+		})
+	}
+}
+
+func TestValidateMacroSource_ImplicitStringConcatenation(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		language string
+		wantWarn bool
+		wantLine int // expected line number in warning (1-indexed)
+	}{
+		{
+			name:     "adjacent double-quoted strings",
+			source:   `def test(): return "hello" "world"`,
+			language: "starlark",
+			wantWarn: true,
+			wantLine: 1,
+		},
+		{
+			name:     "adjacent single-quoted strings",
+			source:   `def test(): return 'hello' 'world'`,
+			language: "starlark",
+			wantWarn: true,
+			wantLine: 1,
+		},
+		{
+			name:     "adjacent strings on multiline",
+			source:   "def test():\n    result = \"hello\" \"world\"\n    return result",
+			language: "starlark",
+			wantWarn: true,
+			wantLine: 2,
+		},
+		{
+			name:     "no adjacent strings",
+			source:   `def test(): return "hello" + "world"`,
+			language: "starlark",
+			wantWarn: false,
+		},
+		{
+			name:     "strings separated by operator",
+			source:   `def test(): return "hello" + "world"`,
+			language: "starlark",
+			wantWarn: false,
+		},
+		{
+			name:     "strings on different lines",
+			source:   "def test():\n    a = \"hello\"\n    b = \"world\"",
+			language: "starlark",
+			wantWarn: false,
+		},
+		{
+			name:     "adjacent strings in Python macro (should not warn)",
+			source:   `def test(): return "hello" "world"`,
+			language: "python",
+			wantWarn: false,
+		},
+		{
+			name:     "user's example - string concatenation with +",
+			source:   "def versions(data):\n    software_version = str(data[\"major\"]) + \".\" + \\\n                       str(data[\"minor\"]) + \".\" + \\\n                       str(data[\"patch\"]) + \", Ver \" + \\\n                       str(data[\"version\"]) + \",\" + \\\n                       str(data[\"build\"])\n    data[\"software-version\"] = software_version\n    return data",
+			language: "starlark",
+			wantWarn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := ValidateMacroSource(tt.source, tt.language)
+			hasConcatenationWarning := false
+			for _, w := range warnings {
+				if strings.Contains(w, "implicit string concatenation") {
+					hasConcatenationWarning = true
+					break
+				}
+			}
+
+			if hasConcatenationWarning != tt.wantWarn {
+				t.Errorf("ValidateMacroSource() implicit concatenation warning = %v, want %v. Warnings: %v", hasConcatenationWarning, tt.wantWarn, warnings)
+			}
+		})
+	}
+}
+
+func TestValidateMacroSource_CombinedWarnings(t *testing.T) {
+	tests := []struct {
+		name           string
+		source         string
+		language       string
+		wantFString    bool
+		wantConcatenation bool
+	}{
+		{
+			name:           "both f-string and implicit concatenation",
+			source:         `def test(): return f"{data}" "extra"`,
+			language:       "starlark",
+			wantFString:    true,
+			wantConcatenation: true,
+		},
+		{
+			name:           "only f-string",
+			source:         `def test(): return f"{data}"`,
+			language:       "starlark",
+			wantFString:    true,
+			wantConcatenation: false,
+		},
+		{
+			name:           "only implicit concatenation",
+			source:         `def test(): return "hello" "world"`,
+			language:       "starlark",
+			wantFString:    false,
+			wantConcatenation: true,
+		},
+		{
+			name:           "neither issue",
+			source:         `def test(): return "hello" + "world"`,
+			language:       "starlark",
+			wantFString:    false,
+			wantConcatenation: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := ValidateMacroSource(tt.source, tt.language)
+			
+			hasFString := false
+			hasConcatenation := false
+			for _, w := range warnings {
+				if strings.Contains(w, "f-string") {
+					hasFString = true
+				}
+				if strings.Contains(w, "implicit string concatenation") {
+					hasConcatenation = true
+				}
+			}
+
+			if hasFString != tt.wantFString {
+				t.Errorf("ValidateMacroSource() f-string warning = %v, want %v", hasFString, tt.wantFString)
+			}
+			if hasConcatenation != tt.wantConcatenation {
+				t.Errorf("ValidateMacroSource() concatenation warning = %v, want %v", hasConcatenation, tt.wantConcatenation)
+			}
+		})
+	}
+}
+
+func TestValidateMacroSource_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		language string
+		wantWarn bool
+	}{
+		{
+			name:     "empty source",
+			source:   "",
+			language: "starlark",
+			wantWarn: false,
+		},
+		{
+			name:     "source with 'f' but not f-string",
+			source:   `def test(): return "file.txt"`,
+			language: "starlark",
+			wantWarn: false,
+		},
+		{
+			name:     "f in variable name",
+			source:   `def test(): f = "value"; return f`,
+			language: "starlark",
+			wantWarn: false,
+		},
+		{
+			name:     "f-string in comment",
+			source:   `def test(): # f"comment"\n    return "value"`,
+			language: "starlark",
+			wantWarn: true, // Our simple regex will match this, which is acceptable
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := ValidateMacroSource(tt.source, tt.language)
+			hasWarning := len(warnings) > 0
+
+			if hasWarning != tt.wantWarn {
+				t.Errorf("ValidateMacroSource() warning = %v, want %v. Warnings: %v", hasWarning, tt.wantWarn, warnings)
+			}
+		})
+	}
+}
+

--- a/internal/validator/template.go
+++ b/internal/validator/template.go
@@ -60,6 +60,14 @@ func (v *Validator) ValidateTemplate(tmpl *parser.Template) *ValidationResult {
 		v.validateLookup(lookup, tmpl.Name, result)
 	}
 
+	// Validate macros
+	for _, macro := range tmpl.Macros {
+		macroWarnings := ValidateMacroSource(macro.Content, macro.Language)
+		for _, warning := range macroWarnings {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("macro (language=%s): %s", macro.Language, warning))
+		}
+	}
+
 	result.Valid = len(result.Errors) == 0
 	return result
 }
@@ -245,5 +253,41 @@ func (v *Validator) ValidateTemplateString(templateStr, templateName string) *Va
 
 	result.Valid = len(result.Errors) == 0
 	return result
+}
+
+// ValidateMacroSource validates macro source code and returns warnings for
+// Python-specific features that are not compatible with Starlark
+func ValidateMacroSource(source, language string) []string {
+	var warnings []string
+	
+	// Only validate Starlark macros (default) - Python macros are expected to use Python syntax
+	if language != "" && language != "starlark" {
+		return warnings
+	}
+	
+	// Check for Python f-strings (f"..." or f'...')
+	fStringPattern := regexp.MustCompile(`\bf["']`)
+	if fStringPattern.MatchString(source) {
+		warnings = append(warnings, "macro contains Python f-string syntax (f\"...\" or f'...'). Starlark does not support f-strings. Use string concatenation with + or .format() instead.")
+	}
+	
+	// Check for implicit string concatenation (adjacent string literals)
+	// Pattern: "string1" "string2" or 'string1' 'string2'
+	// This is tricky because we need to avoid matching strings that are part of expressions
+	// We'll look for patterns like: "..." "..." or '...' '...' on the same line
+	// Go's regexp doesn't support backreferences, so we'll check for both patterns separately
+	lines := strings.Split(source, "\n")
+	for lineNum, line := range lines {
+		// Look for adjacent double-quoted strings: "..." "..."
+		doubleQuotePattern := regexp.MustCompile(`"[^"]*"\s+"[^"]*"`)
+		// Look for adjacent single-quoted strings: '...' '...'
+		singleQuotePattern := regexp.MustCompile(`'[^']*'\s+'[^']*'`)
+		
+		if doubleQuotePattern.MatchString(line) || singleQuotePattern.MatchString(line) {
+			warnings = append(warnings, fmt.Sprintf("macro contains implicit string concatenation (adjacent string literals) on line %d. Starlark does not support implicit concatenation. Use + operator to concatenate strings explicitly.", lineNum+1))
+		}
+	}
+	
+	return warnings
 }
 


### PR DESCRIPTION
…cros

- Revert f-string conversion code (removed convertPythonFStrings function)
- Add ValidateMacroSource function to detect f-strings and implicit string concatenation
- Integrate macro validation into compiler to collect warnings during compilation
- Add Warnings field to CompiledTemplate to store compilation warnings
- Expose warnings via GetWarnings() method in public API
- Update WASM bridge to return warnings from compileTemplate
- Add Monaco editor markers to highlight macro warnings in template editor
- Display warnings as notifications in editor (moved to bottom-right corner)
- Add comprehensive test coverage for macro validation
- Update existing test to verify f-strings are rejected (not converted)

This provides compile-time warnings for Python-specific syntax that's not compatible with Starlark, helping users identify issues before runtime. Warnings are non-fatal and templates will still compile and run.

## Description
Brief description of changes

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other (please describe) What seemed like a bug was just unsupported syntax in starlark that was unexpected, added compiler warnings to notify the user what was happening.

## Testing
- [X] Tests pass locally
- [X] Added new tests
- [ ] Updated existing tests

## Checklist
- [X] Code follows project style guidelines
- [X] Self-review completed
- [X] Comments added for complex code
- [X] Documentation updated
- [ ] No new warnings generated - We purposely added warnings.

Closes #3 