### PR TITLE
perf: cut parseGroup/extractMatchResult allocations (refs #18)

### DIFF
--- a/internal/compiled/runtime.go
+++ b/internal/compiled/runtime.go
@@ -1258,12 +1258,7 @@ func (r *Runtime) parseGroup(group *compiler.CompiledGroup, inputData string, va
 
 	for patternIdx, compiledPattern := range group.Patterns {
 
-		// Check if pattern has line anchors (^ and $)
-		// Note: Original is the template line, not the regex, so we check the compiled regex
-		hasAnchors := strings.Contains(compiledPattern.Regex.String(), "^") ||
-			strings.Contains(compiledPattern.Regex.String(), "$")
-
-		if hasAnchors {
+		if compiledPattern.HasAnchors {
 			// Match line by line
 			for lineIdx, line := range lines {
 				// Trim \r and trailing spaces, but preserve leading spaces for regex matching
@@ -1311,42 +1306,7 @@ func (r *Runtime) parseGroup(group *compiler.CompiledGroup, inputData string, va
 
 				if match != nil {
 					result := r.extractMatchResult(match, compiledPattern, vars)
-					// Allow matches even if result is empty (e.g., patterns with only _start_, _end_, or _line_)
-					// Check if this pattern has only special indicators
-					// Note: _exact_ and _exact_space_ are indicators, not variables that capture values
-					hasOnlySpecialIndicators := true
-					for varName := range compiledPattern.Variables {
-						if varName != "ignore" && varName != "_start_" && varName != "_end_" && varName != "_line_" && varName != "_exact_" && varName != "_exact_space_" {
-							hasOnlySpecialIndicators = false
-							break
-						}
-					}
-
-					// Check if ignore uses template variable - if so, allow empty result
-					ignoreUsesTemplateVar := false
-					for _, variable := range compiledPattern.Variables {
-						if variable.Name == "ignore" && variable.IgnoreUsesTemplateVar {
-							ignoreUsesTemplateVar = true
-							break
-						}
-					}
-
-					// Check if this pattern has joinmatches - if so, allow empty results
-					// (they will be filtered during collection)
-					hasJoinMatches := false
-					for _, variable := range compiledPattern.Variables {
-						for _, funcStr := range variable.Functions {
-							if strings.HasPrefix(funcStr, "joinmatches") {
-								hasJoinMatches = true
-								break
-							}
-						}
-						if hasJoinMatches {
-							break
-						}
-					}
-
-					if result != nil && (len(result) > 0 || hasOnlySpecialIndicators || ignoreUsesTemplateVar || hasJoinMatches) {
+					if result != nil && (len(result) > 0 || compiledPattern.HasOnlySpecialIndicators || compiledPattern.IgnoreUsesTemplateVar || compiledPattern.HasJoinMatches) {
 						spanStart := lineOffsets[lineIdx]
 						spanEnd := lineOffsets[lineIdx] + len(line)
 						allMatches = append(allMatches, patternMatch{
@@ -1379,15 +1339,7 @@ func (r *Runtime) parseGroup(group *compiler.CompiledGroup, inputData string, va
 
 				// Extract result
 				result := r.extractMatchResult(matchGroups, compiledPattern, vars)
-				// Check if ignore uses template variable - if so, allow empty result
-				ignoreUsesTemplateVar := false
-				for _, variable := range compiledPattern.Variables {
-					if variable.Name == "ignore" && variable.IgnoreUsesTemplateVar {
-						ignoreUsesTemplateVar = true
-						break
-					}
-				}
-				if result != nil && (len(result) > 0 || ignoreUsesTemplateVar) {
+				if result != nil && (len(result) > 0 || compiledPattern.IgnoreUsesTemplateVar) {
 					allMatches = append(allMatches, patternMatch{
 						patternIdx: patternIdx,
 						spanStart:  indices[0],
@@ -2278,13 +2230,8 @@ func (r *Runtime) parseGroup(group *compiler.CompiledGroup, inputData string, va
 					// Check if ignore uses template variable - if so, clear the match
 					ignoreUsesTemplateVar := false
 					for _, compiledPattern := range group.Patterns {
-						for _, variable := range compiledPattern.Variables {
-							if variable.Name == "ignore" && variable.IgnoreUsesTemplateVar {
-								ignoreUsesTemplateVar = true
-								break
-							}
-						}
-						if ignoreUsesTemplateVar {
+						if compiledPattern.IgnoreUsesTemplateVar {
+							ignoreUsesTemplateVar = true
 							break
 						}
 					}
@@ -2308,13 +2255,8 @@ func (r *Runtime) parseGroup(group *compiler.CompiledGroup, inputData string, va
 				// Check if ignore uses template variable - if so, don't copy result fields
 				ignoreUsesTemplateVar := false
 				for _, compiledPattern := range group.Patterns {
-					for _, variable := range compiledPattern.Variables {
-						if variable.Name == "ignore" && variable.IgnoreUsesTemplateVar {
-							ignoreUsesTemplateVar = true
-							break
-						}
-					}
-					if ignoreUsesTemplateVar {
+					if compiledPattern.IgnoreUsesTemplateVar {
+						ignoreUsesTemplateVar = true
 						break
 					}
 				}
@@ -4392,10 +4334,7 @@ func (r *Runtime) parseGroupWithSourceMap(group *compiler.CompiledGroup, inputDa
 	lineOffsets[len(lines)] = offset
 
 	for patternIdx, compiledPattern := range group.Patterns {
-		hasAnchors := strings.Contains(compiledPattern.Regex.String(), "^") ||
-			strings.Contains(compiledPattern.Regex.String(), "$")
-
-		if hasAnchors {
+		if compiledPattern.HasAnchors {
 			// Match line by line
 			for lineIdx, line := range lines {
 				line = strings.TrimRight(line, "\r \t")
@@ -4441,37 +4380,8 @@ func (r *Runtime) parseGroupWithSourceMap(group *compiler.CompiledGroup, inputDa
 					}
 
 					result := r.extractMatchResult(match, compiledPattern, vars)
-					
-					hasOnlySpecialIndicators := true
-					for varName := range compiledPattern.Variables {
-						if varName != "ignore" && varName != "_start_" && varName != "_end_" && varName != "_line_" && varName != "_exact_" && varName != "_exact_space_" {
-							hasOnlySpecialIndicators = false
-							break
-						}
-					}
 
-					ignoreUsesTemplateVar := false
-					for _, variable := range compiledPattern.Variables {
-						if variable.Name == "ignore" && variable.IgnoreUsesTemplateVar {
-							ignoreUsesTemplateVar = true
-							break
-						}
-					}
-
-					hasJoinMatches := false
-					for _, variable := range compiledPattern.Variables {
-						for _, funcStr := range variable.Functions {
-							if strings.HasPrefix(funcStr, "joinmatches") {
-								hasJoinMatches = true
-								break
-							}
-						}
-						if hasJoinMatches {
-							break
-						}
-					}
-
-					if result != nil && (len(result) > 0 || hasOnlySpecialIndicators || ignoreUsesTemplateVar || hasJoinMatches) {
+					if result != nil && (len(result) > 0 || compiledPattern.HasOnlySpecialIndicators || compiledPattern.IgnoreUsesTemplateVar || compiledPattern.HasJoinMatches) {
 						spanStart := lineOffsets[lineIdx] + matchIndices[0]
 						spanEnd := lineOffsets[lineIdx] + matchIndices[1]
 						
@@ -4532,15 +4442,7 @@ func (r *Runtime) parseGroupWithSourceMap(group *compiler.CompiledGroup, inputDa
 				}
 
 				result := r.extractMatchResult(matchGroups, compiledPattern, vars)
-				ignoreUsesTemplateVar := false
-				for _, variable := range compiledPattern.Variables {
-					if variable.Name == "ignore" && variable.IgnoreUsesTemplateVar {
-						ignoreUsesTemplateVar = true
-						break
-					}
-				}
-				
-				if result != nil && (len(result) > 0 || ignoreUsesTemplateVar) {
+				if result != nil && (len(result) > 0 || compiledPattern.IgnoreUsesTemplateVar) {
 					// Find which line this match is on
 					lineIdx := 0
 					for i, offset := range lineOffsets {
@@ -5021,10 +4923,7 @@ func (r *Runtime) parseGroupWithSourceMap(group *compiler.CompiledGroup, inputDa
 				parentLines := strings.Split(parentInputData, "\n")
 				
 				for patternIdx, compiledPattern := range nestedGroup.Patterns {
-					hasAnchors := strings.Contains(compiledPattern.Regex.String(), "^") ||
-						strings.Contains(compiledPattern.Regex.String(), "$")
-
-					if hasAnchors {
+					if compiledPattern.HasAnchors {
 						// Match line by line within parent range
 						for localLineIdx, line := range parentLines {
 							absoluteLineIdx := rangeStartLine + localLineIdx
@@ -5229,10 +5128,7 @@ func (r *Runtime) parseGroupWithSourceMap(group *compiler.CompiledGroup, inputDa
 					
 					// Process child group patterns within this nested group's range
 					for patternIdx, compiledPattern := range childGroup.Patterns {
-						hasAnchors := strings.Contains(compiledPattern.Regex.String(), "^") ||
-							strings.Contains(compiledPattern.Regex.String(), "$")
-						
-						if hasAnchors {
+						if compiledPattern.HasAnchors {
 							// Match line by line within nested group range
 							for lineIdx := nr.startLine; lineIdx < nr.endLine && lineIdx < len(inputSourceMap.Lines); lineIdx++ {
 								if lineIdx < 0 || lineIdx >= len(lines) {
@@ -5708,21 +5604,12 @@ func (r *Runtime) extractMatchResult(match []string, compiledPattern *pattern.Co
 			continue
 		}
 
-		// Check if this variable has set() function - if so, we need to process it even if it doesn't match
-		hasSet := false
-		for _, funcStr := range variable.Functions {
-			if strings.HasPrefix(funcStr, "set(") {
-				hasSet = true
-				break
-			}
-		}
-
 		// For variables with set(), we need to process them even if they don't match (varIndex >= len(match))
 		// The set() function will set the value regardless of what was matched
 		var value interface{}
 		if varIndex < len(match) {
 			value = match[varIndex]
-		} else if hasSet {
+		} else if variable.HasSet {
 			// Variable with set() didn't match - use empty string as value
 			// The set() function will set the actual value
 			value = ""
@@ -5730,15 +5617,6 @@ func (r *Runtime) extractMatchResult(match []string, compiledPattern *pattern.Co
 			// Variable didn't match and doesn't have set() - skip it
 			varIndex++
 			continue
-		}
-
-		// Check if this variable has joinmatches function
-		hasJoinMatches := false
-		for _, funcStr := range variable.Functions {
-			if strings.HasPrefix(funcStr, "joinmatches") {
-				hasJoinMatches = true
-				break
-			}
 		}
 
 		// Pass match result data structure to processFunctions so let and set can set additional fields
@@ -5754,7 +5632,7 @@ func (r *Runtime) extractMatchResult(match []string, compiledPattern *pattern.Co
 		// Apply functions if any (but handle joinmatches specially)
 		var processedValue interface{}
 		var err error
-		if hasJoinMatches {
+		if variable.HasJoinMatches {
 			// For joinmatches, collect the value but don't apply joinmatches yet
 			// We'll collect all matches and join them later
 			// Apply other functions first
@@ -5793,7 +5671,7 @@ func (r *Runtime) extractMatchResult(match []string, compiledPattern *pattern.Co
 		// If variable has set() function, it should set a value in the match result
 		// The set function should have already set it via _match_data
 		// For set(), we don't save the processedValue - the set function sets the value directly
-		if hasSet {
+		if variable.HasSet {
 			// The set function should have already set the value in result via _match_data
 			// Don't overwrite it with processedValue - set() handles the value setting
 			// Just skip saving processedValue - the value is already set by set()
@@ -5805,7 +5683,7 @@ func (r *Runtime) extractMatchResult(match []string, compiledPattern *pattern.Co
 		// so it can be collected during merging
 		// Store the processed value as-is (to_list will have already wrapped it if needed)
 		// The value will be collected during the merging phase
-		if hasJoinMatches {
+		if variable.HasJoinMatches {
 			// For joinmatches, we need to collect the value
 			// The value will be joined later in the merging phase
 			// Store as list to prepare for joining

--- a/internal/compiled/runtime.go
+++ b/internal/compiled/runtime.go
@@ -5393,7 +5393,7 @@ func (r *Runtime) searchNestedGroupInMap(m map[string]interface{}, nestedGroupNa
 
 // processFunctions applies function pipeline to a value
 // Returns an error with message "condition_failed" if a condition function returns false
-func (r *Runtime) processFunctions(value interface{}, functions []string, vars map[string]interface{}) (interface{}, error) {
+func (r *Runtime) processFunctions(value interface{}, functions []string, vars map[string]interface{}, matchData map[string]interface{}, varName string) (interface{}, error) {
 	result := value
 
 	// Pre-allocate kwargs map only if needed (for functions that require vars)
@@ -5502,10 +5502,10 @@ func (r *Runtime) processFunctions(value interface{}, functions []string, vars m
 
 			// Pass match result data structure to let and set functions so they can set additional fields
 			if funcName == "let" || funcName == "set" {
-				if matchData, ok := vars["_match_data"]; ok {
+				if matchData != nil {
 					kwargs["_match_data"] = matchData
 				}
-				if varName, ok := vars["_var_name"]; ok {
+				if varName != "" {
 					kwargs["_var_name"] = varName
 				}
 			}
@@ -5532,7 +5532,7 @@ func (r *Runtime) processFunctions(value interface{}, functions []string, vars m
 				}
 				kwargs["_lookup_tables"] = lookupTables
 				// Also pass match data for add_field support
-				if matchData, ok := vars["_match_data"]; ok {
+				if matchData != nil {
 					kwargs["_match_data"] = matchData
 				}
 			}
@@ -5619,17 +5619,9 @@ func (r *Runtime) extractMatchResult(match []string, compiledPattern *pattern.Co
 			continue
 		}
 
-		// Pass match result data structure to processFunctions so let and set can set additional fields
-		// Create a copy of vars with _match_data pointing to the result map
-		processVars := make(map[string]interface{})
-		for k, v := range vars {
-			processVars[k] = v
-		}
-		processVars["_match_data"] = result
-		// Also pass the variable name so set can use it
-		processVars["_var_name"] = variable.Name
-
-		// Apply functions if any (but handle joinmatches specially)
+		// Apply functions if any (but handle joinmatches specially).
+		// Pass result + variable.Name as explicit matchData/varName so we
+		// avoid cloning vars per variable just to inject _match_data/_var_name.
 		var processedValue interface{}
 		var err error
 		if variable.HasJoinMatches {
@@ -5642,7 +5634,7 @@ func (r *Runtime) extractMatchResult(match []string, compiledPattern *pattern.Co
 					otherFuncs = append(otherFuncs, funcStr)
 				}
 			}
-			processedValue, err = r.processFunctions(value, otherFuncs, processVars)
+			processedValue, err = r.processFunctions(value, otherFuncs, vars, result, variable.Name)
 			if err != nil {
 				// Check if it's a condition failure
 				if strings.Contains(err.Error(), "condition_failed") {
@@ -5656,7 +5648,7 @@ func (r *Runtime) extractMatchResult(match []string, compiledPattern *pattern.Co
 				continue
 			}
 		} else {
-			processedValue, err = r.processFunctions(value, variable.Functions, processVars)
+			processedValue, err = r.processFunctions(value, variable.Functions, vars, result, variable.Name)
 			if err != nil {
 				// Check if it's a condition failure
 				if strings.Contains(err.Error(), "condition_failed") {

--- a/internal/compiled/runtime.go
+++ b/internal/compiled/runtime.go
@@ -5570,16 +5570,11 @@ func (r *Runtime) processFunctions(value interface{}, functions []string, vars m
 func (r *Runtime) extractMatchResult(match []string, compiledPattern *pattern.CompiledPattern, vars map[string]interface{}) map[string]interface{} {
 	// Python TTP quirk: when ignore() uses a template variable, return empty result
 	// This causes the match to be added but with no fields (matches Python TTP behavior)
-	for _, variable := range compiledPattern.Variables {
-		if variable.Name == "ignore" && variable.IgnoreUsesTemplateVar {
-			// Return empty result to match Python TTP's behavior
-			// The empty result will be added to matches (Python TTP returns [{}])
-			return make(map[string]interface{})
-		}
+	if compiledPattern.IgnoreUsesTemplateVar {
+		// Return empty result to match Python TTP's behavior
+		// The empty result will be added to matches (Python TTP returns [{}])
+		return make(map[string]interface{})
 	}
-
-	result := make(map[string]interface{})
-	varIndex := 1 // First capture group is at index 1 (index 0 is full match)
 
 	// Use the preserved variable order from the pattern
 	varNames := compiledPattern.VariableOrder
@@ -5589,6 +5584,11 @@ func (r *Runtime) extractMatchResult(match []string, compiledPattern *pattern.Co
 			varNames = append(varNames, varName)
 		}
 	}
+
+	// Pre-size result map: most variables produce a single key, so VariableOrder
+	// length is a tight upper bound and avoids map growth/rehash for wide patterns.
+	result := make(map[string]interface{}, len(varNames))
+	varIndex := 1 // First capture group is at index 1 (index 0 is full match)
 
 	// Extract values in order
 	for _, varName := range varNames {

--- a/internal/compiler/compiled.go
+++ b/internal/compiler/compiled.go
@@ -527,12 +527,14 @@ func (c *Compiler) compilePatternWithVars(line string, exactSpace, exact bool, v
 		varOrder[i] = v.Name
 	}
 
-	return &pattern.CompiledPattern{
+	cp := &pattern.CompiledPattern{
 		Regex:         compiled,
 		Variables:     varMap,
 		VariableOrder: varOrder,
 		Original:      line,
-	}, nil
+	}
+	cp.PopulateFlags()
+	return cp, nil
 }
 
 // splitLines splits text into lines, preserving empty lines

--- a/internal/pattern/cached_flags_test.go
+++ b/internal/pattern/cached_flags_test.go
@@ -1,0 +1,113 @@
+package pattern
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCachedFlagsParity verifies that the compile-time cached booleans on
+// CompiledPattern and MatchVariable match the on-the-fly computation that
+// the runtime previously did per-match. Each case exercises a different
+// indicator/function combination so a regression in the population logic
+// shows up here rather than as a behavior change in parsing.
+func TestCachedFlagsParity(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"plain", "interface {{ interface }} ip {{ ip }}"},
+		{"with_set", "interface {{ interface }} {{ source | set('cli') }}"},
+		{"with_joinmatches", "description {{ desc | joinmatches }}"},
+		{"start_indicator", "_start_"},
+		{"end_indicator", "_end_"},
+		{"line_indicator", "_line_"},
+		{"with_ignore", "{{ ignore }} {{ name }}"},
+		{"only_specials", "_start_"},
+	}
+
+	engine := NewEngine()
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cp, err := engine.CompilePattern(tc.line, false, false)
+			if err != nil {
+				t.Fatalf("CompilePattern(%q): %v", tc.line, err)
+			}
+
+			// Pattern-level flags
+			expectedHasAnchors := strings.Contains(cp.Regex.String(), "^") ||
+				strings.Contains(cp.Regex.String(), "$")
+			if cp.HasAnchors != expectedHasAnchors {
+				t.Errorf("HasAnchors: got %v, want %v", cp.HasAnchors, expectedHasAnchors)
+			}
+
+			expectedHasOnlySpecial := true
+			for varName := range cp.Variables {
+				if varName != "ignore" && varName != "_start_" && varName != "_end_" &&
+					varName != "_line_" && varName != "_exact_" && varName != "_exact_space_" {
+					expectedHasOnlySpecial = false
+					break
+				}
+			}
+			if cp.HasOnlySpecialIndicators != expectedHasOnlySpecial {
+				t.Errorf("HasOnlySpecialIndicators: got %v, want %v",
+					cp.HasOnlySpecialIndicators, expectedHasOnlySpecial)
+			}
+
+			expectedIgnoreUsesTemplateVar := false
+			for _, v := range cp.Variables {
+				if v.Name == "ignore" && v.IgnoreUsesTemplateVar {
+					expectedIgnoreUsesTemplateVar = true
+					break
+				}
+			}
+			if cp.IgnoreUsesTemplateVar != expectedIgnoreUsesTemplateVar {
+				t.Errorf("IgnoreUsesTemplateVar: got %v, want %v",
+					cp.IgnoreUsesTemplateVar, expectedIgnoreUsesTemplateVar)
+			}
+
+			expectedPatternHasJoinMatches := false
+			for _, v := range cp.Variables {
+				for _, f := range v.Functions {
+					if strings.HasPrefix(f, "joinmatches") {
+						expectedPatternHasJoinMatches = true
+						break
+					}
+				}
+				if expectedPatternHasJoinMatches {
+					break
+				}
+			}
+			if cp.HasJoinMatches != expectedPatternHasJoinMatches {
+				t.Errorf("CompiledPattern.HasJoinMatches: got %v, want %v",
+					cp.HasJoinMatches, expectedPatternHasJoinMatches)
+			}
+
+			// Variable-level flags
+			for _, v := range cp.Variables {
+				expectedHasSet := false
+				for _, f := range v.Functions {
+					if strings.HasPrefix(f, "set(") {
+						expectedHasSet = true
+						break
+					}
+				}
+				if v.HasSet != expectedHasSet {
+					t.Errorf("var %q HasSet: got %v, want %v", v.Name, v.HasSet, expectedHasSet)
+				}
+
+				expectedVarHasJoinMatches := false
+				for _, f := range v.Functions {
+					if strings.HasPrefix(f, "joinmatches") {
+						expectedVarHasJoinMatches = true
+						break
+					}
+				}
+				if v.HasJoinMatches != expectedVarHasJoinMatches {
+					t.Errorf("var %q HasJoinMatches: got %v, want %v",
+						v.Name, v.HasJoinMatches, expectedVarHasJoinMatches)
+				}
+			}
+		})
+	}
+}

--- a/internal/pattern/engine.go
+++ b/internal/pattern/engine.go
@@ -28,6 +28,11 @@ type MatchVariable struct {
 	Functions             []string // function pipeline
 	Pattern               string   // regex pattern for this variable
 	IgnoreUsesTemplateVar bool     // true if ignore() uses a template variable (Python TTP quirk: returns empty result)
+
+	// Compile-time cached function flags. Populated by CompiledPattern.PopulateFlags
+	// to avoid per-match scans of Functions in the runtime hot path.
+	HasSet         bool // any function starts with "set("
+	HasJoinMatches bool // any function starts with "joinmatches"
 }
 
 // CompiledPattern represents a compiled regex pattern with variable information
@@ -36,6 +41,59 @@ type CompiledPattern struct {
 	Variables     map[string]*MatchVariable
 	VariableOrder []string // Order of variables as they appear in the pattern
 	Original      string
+
+	// Compile-time cached flags consumed by the runtime hot path. Populated by
+	// PopulateFlags after Variables and Regex are assigned.
+	HasAnchors               bool // regex contains ^ or $ -> match line-by-line
+	HasOnlySpecialIndicators bool // every variable is ignore/_start_/_end_/_line_/_exact_/_exact_space_
+	IgnoreUsesTemplateVar    bool // any "ignore" variable has IgnoreUsesTemplateVar=true
+	HasJoinMatches           bool // any variable has a joinmatches function
+}
+
+// PopulateFlags computes the compile-time cached booleans from the pattern's
+// regex and variable functions. Must be called after Regex and Variables are
+// assigned. Idempotent.
+func (cp *CompiledPattern) PopulateFlags() {
+	regexStr := ""
+	if cp.Regex != nil {
+		regexStr = cp.Regex.String()
+	}
+	cp.HasAnchors = strings.Contains(regexStr, "^") || strings.Contains(regexStr, "$")
+
+	hasOnlySpecial := true
+	ignoreUsesTemplateVar := false
+	patternHasJoinMatches := false
+	for _, v := range cp.Variables {
+		if v.Name != "ignore" && v.Name != "_start_" && v.Name != "_end_" &&
+			v.Name != "_line_" && v.Name != "_exact_" && v.Name != "_exact_space_" {
+			hasOnlySpecial = false
+		}
+		if v.Name == "ignore" && v.IgnoreUsesTemplateVar {
+			ignoreUsesTemplateVar = true
+		}
+
+		varHasSet := false
+		varHasJoinMatches := false
+		for _, f := range v.Functions {
+			if !varHasSet && strings.HasPrefix(f, "set(") {
+				varHasSet = true
+			}
+			if !varHasJoinMatches && strings.HasPrefix(f, "joinmatches") {
+				varHasJoinMatches = true
+			}
+			if varHasSet && varHasJoinMatches {
+				break
+			}
+		}
+		v.HasSet = varHasSet
+		v.HasJoinMatches = varHasJoinMatches
+		if varHasJoinMatches {
+			patternHasJoinMatches = true
+		}
+	}
+	cp.HasOnlySpecialIndicators = hasOnlySpecial
+	cp.IgnoreUsesTemplateVar = ignoreUsesTemplateVar
+	cp.HasJoinMatches = patternHasJoinMatches
 }
 
 // Engine handles pattern generation and compilation
@@ -566,12 +624,14 @@ func (e *Engine) CompilePattern(line string, exactSpace, exact bool) (*CompiledP
 		varOrder[i] = v.Name
 	}
 
-	return &CompiledPattern{
+	cp := &CompiledPattern{
 		Regex:         compiled,
 		Variables:     varMap,
 		VariableOrder: varOrder,
 		Original:      line,
-	}, nil
+	}
+	cp.PopulateFlags()
+	return cp, nil
 }
 
 // validatePattern validates a pattern string for common regex errors

--- a/test/comparison/parsegroup_alloc_bench_test.go
+++ b/test/comparison/parsegroup_alloc_bench_test.go
@@ -1,0 +1,45 @@
+package comparison
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/roc-ops/gottp"
+)
+
+// BenchmarkParseGroupCableModem exercises the parseGroup / extractMatchResult
+// hot path against the cable_modem_input.txt fixture (~6235 rows). Tracks both
+// time and allocations so we can compare before/after for perf changes
+// targeting GC pressure (see issue #18).
+func BenchmarkParseGroupCableModem(b *testing.B) {
+	template := `<group name="show_cable_modem*">
+{{mac-address | MAC}} {{ip-address | IP}}         {{us-intf}}      {{ds-intf}}     {{status}}     {{prim-sid}}    {{rx-power}}    {{timing-offset}}      {{num-cpes}}    {{bpi-enabled}}  {{rphy-node}}    {{mac-domain}}
+</group>`
+
+	root, err := getProjectRoot()
+	if err != nil {
+		b.Fatalf("getProjectRoot: %v", err)
+	}
+	fixture := filepath.Join(root, "test", "comparison", "fixtures", "cable_modem_input.txt")
+	bytes, err := os.ReadFile(fixture)
+	if err != nil {
+		b.Fatalf("read fixture: %v", err)
+	}
+	data := string(bytes)
+
+	compiled, err := gottp.CompileTemplate(template)
+	if err != nil {
+		b.Fatalf("compile: %v", err)
+	}
+
+	inputs := gottp.Inputs{"Default_Input": data}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := compiled.Parse(inputs, nil, nil); err != nil {
+			b.Fatalf("parse: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #18 contingent on prod-profile validation post-deploy.

## Summary

Targets the `parseGroup` / `extractMatchResult` alloc-rate findings from issue #18 (DH360 Discovery's pprof on a Vyve CMTS at ~9000 modems, where ~30% of CPU was in `runtime.scanobject` / `mallocgc`). Three changes, plus a local benchmark:

- **Cache compile-time flags** on `CompiledPattern` / `MatchVariable` (`HasAnchors`, `HasOnlySpecialIndicators`, `IgnoreUsesTemplateVar`, `HasJoinMatches`, per-variable `HasSet` / `HasJoinMatches`). Replaces ~9 per-match scan loops in `parseGroup`, `parseGroupWithSourceMap`, the nested-group helpers, and `extractMatchResult`. Parity enforced by new `TestCachedFlagsParity`.
- **Gate `processVars` clone** in `extractMatchResult`. The per-variable map clone was unconditional — `processFunctions` already had its own `needsKwargs` gate, so the upstream clone was pure overhead. `processFunctions` now takes `matchData` / `varName` as explicit params and only injects them into kwargs when calling let/set/lookup.
- **Pre-size the `result` map** to `len(VariableOrder)`; short-circuit the `IgnoreUsesTemplateVar` path with the cached field instead of looping.

## Local benchmark

`BenchmarkParseGroupCableModem` against the existing 6235-row `cable_modem_input.txt` fixture, 20 iterations:

| | main | branch | Δ |
|---|---:|---:|---:|
| Time | 68.7 ms | 46.3 ms | **−32.6%** |
| Bytes | 48.5 MB | 45.5 MB | −6.2% |
| Allocs | 536,271 | 455,256 | **−15.1%** |

~81K allocations dropped per parse — matches the issue's prediction (~12 vars × 6235 rows for the `processVars` clone alone). Local benchmark can't reflect GC-amortized cost at prod scale; the real validation is the next DH-side pprof post-deploy.

## Notes on issue scope

- Skipped issue point #3 (`strings.Split` hoist) — verified the split is already outside the per-pattern loop in both `parseGroup` and `parseGroupWithSourceMap` since the initial commit. No-op.
- Skipped issue point #5 (`sync.Pool` for transient slices) — `patternMatch.result` ownership transfers downstream, so pooling needs careful lifetime analysis. Smaller upside now that the clone gate has landed; can revisit if prod profile still shows GC pressure.

## Test plan

- [x] `go test ./...` green on branch (including the 166s `test/comparison` suite)
- [x] New `TestCachedFlagsParity` enforces cached-flag parity with the prior on-the-fly computation
- [x] Local before/after benchmark captured above
- [ ] Deploy gottp, sync DH360 to the new version
- [ ] Re-run DH-side `/debug/pprof/profile` (240s, Vyve CMTS) and confirm `scanobject` + `mallocgc` cumulative drops materially from the ~30% baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)